### PR TITLE
fix: Ensure the member is not nil, and close the snapshot stream befo…

### DIFF
--- a/internal/transport/raftgrpc/client.go
+++ b/internal/transport/raftgrpc/client.go
@@ -137,13 +137,6 @@ func (c *client) snapshot(ctx context.Context, msg etcdraftpb.Message) (err erro
 		return err
 	}
 
-	defer func() {
-		_, rerr := stream.CloseAndRecv()
-		if err == nil {
-			err = rerr
-		}
-	}()
-
 	enc := newEncoder(r)
 	err = enc.Encode(func(c *pb.Chunk) error {
 		return stream.Send(c)
@@ -151,6 +144,10 @@ func (c *client) snapshot(ctx context.Context, msg etcdraftpb.Message) (err erro
 
 	if err != nil {
 		return
+	}
+
+	if _, err := stream.CloseAndRecv(); err != nil {
+		return err
 	}
 
 	return c.message(ctx, msg)

--- a/node.go
+++ b/node.go
@@ -770,7 +770,11 @@ func disableForwarding() func(c *Node) error {
 
 func notType(id uint64, t MemberType) func(c *Node) error {
 	return func(c *Node) error {
-		mem, _ := c.GetMemebr(id)
+		mem, ok := c.GetMemebr(id)
+		if !ok {
+			return fmt.Errorf("raft: unknown member %x", id)
+		}
+
 		if mt := mem.Type(); mt != t {
 			return fmt.Errorf("raft: memebr (%x) is a %s not a %s", id, mt, t)
 		}


### PR DESCRIPTION
…re sending the message to prevent race conditions.